### PR TITLE
Add support for multiple courses

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["env", "stage-3"]
+  "presets": ["env", "stage-3"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/app.js
+++ b/app.js
@@ -5,11 +5,17 @@ const puppeteer = require('puppeteer')
 const wait = require('waait')
 
 // Time between each check in ms
-const msBetweenChecks = 120000
+const msBetweenChecks = 0
+
 // Webadvisor course variables
 const courseSemester = 'F20'
-const courseSubject = 'CIS'
-const courseCode = 3260
+
+// max 5 courses
+const courses = ['CIS*3260', 'UNIV*2100', 'CIS*1250']
+
+// Headless?
+const headless = true
+
 // Start daemon
 start()
 
@@ -24,10 +30,8 @@ async function start() {
 }
 
 async function checkWebadvisor() {
-  // Headful
-  const browser = await puppeteer.launch()
-  // Headless
-  // const browser = await puppeteer.launch()
+  const browser = await puppeteer.launch({ headless })
+
   const page = await browser.newPage()
 
   page.on('console', (msg) => console.log('PAGE LOG:', msg.text()))
@@ -48,11 +52,23 @@ async function checkWebadvisor() {
   // Fill out Search for Sections
   await Promise.all([
     page.select('#VAR1', courseSemester),
-    page.select('#LIST_VAR1_1', courseSubject),
-    page.evaluate(function (courseCode) {
-      const courseCodeInput = document.querySelector('#LIST_VAR3_1')
-      courseCodeInput.value = courseCode
-    }, courseCode),
+    ...courses
+      .map((course, i) => {
+        const row = i + 1
+        const [courseSubject, courseCode] = course.split('*')
+        return [
+          page.select(`#LIST_VAR1_${row}`, courseSubject),
+          page.evaluate(
+            (courseCode, row) => {
+              const courseCodeInput = document.querySelector(`#LIST_VAR3_${row}`)
+              courseCodeInput.value = courseCode
+            },
+            courseCode,
+            row
+          ),
+        ]
+      })
+      .flat(),
   ])
 
   await Promise.all([
@@ -61,27 +77,51 @@ async function checkWebadvisor() {
   ])
 
   // Determine if offering is open - evaluated in browser
-  const open = await page.evaluate(() => {
-    let open = false
+  const availableCourseInfo = await page.evaluate((courses) => {
     const offerings = document.querySelectorAll('#GROUP_Grp_WSS_COURSE_SECTIONS > table > tbody > tr')
+
+    // generate base course map Ex. { 'CIS*1234': [] } cant use ES6 :(
+    const courseMap = {}
+    courses.forEach((course) => (courseMap[course] = []))
+
     offerings.forEach((row, index) => {
       // First two rows are just headings
       if (index < 2) return
-      // Look for a course row that doesn't have the closed styles
-      if (row.className !== 'closed') open = true
-    })
-    return open
-  })
 
-  const now = new Date()
-  console.log(`\nTIME: ${now.getHours()}:${now.getMinutes()}`)
-  const output = `${courseSemester}, ${courseSubject} * ${courseCode}`
-  if (open) {
-    exec(`say "${output} is open"`)
-    console.log('\x1b[32m', `\n${output} IS OPEN`)
-  } else {
-    console.log('\x1b[31m', `\n${output} IS NOT OPEN`)
-  }
+      Object.keys(courseMap).forEach((courseKey) => {
+        // Look for a course row that doesn't have the closed styles
+        if (!row.className && row.className !== 'closed') {
+          if (row.innerText.includes(courseKey)) {
+            // parse columns into array for easy access
+            const splitCourseRow = row.innerText
+              .split('\n\n')
+              .map((s) => s.trim())
+              .filter((s) => s.length)
+
+            // add available course info to course map
+            courseMap[courseKey].push(splitCourseRow)
+          }
+        }
+      })
+    })
+
+    return courseMap
+  }, courses)
+
+  // log time
+  console.log(`\nTIME: ${new Date().toLocaleString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true })}`)
+
+  // check and log open/full sections
+  Object.keys(availableCourseInfo).forEach((courseKey) => {
+    const openSections = availableCourseInfo[courseKey]
+    if (openSections.length) {
+      exec(`say "${courseKey} has available sections"`)
+      // todo: can display the open sections in a nicer format
+      console.log('\x1b[32m', `\n${courseKey} HAS AVAILABLE SECTIONS`, JSON.stringify(openSections))
+    } else {
+      console.log('\x1b[31m', `\n${courseKey} DOES NOT HAVE AVAILABLE SECTIONS`)
+    }
+  })
 
   console.log('\x1b[37m', '\nAYO, THREAD CHECK\n')
   await browser.close()

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-stage-3": "^6.24.1",
     "nodemon": "^2.0.4"


### PR DESCRIPTION
- search availability for multiple courses now! Define courses on app.js:14 like `const courses = ['CIS*3260', 'CIS*1250', ...]`
- learned you cant use es6 inside the page.evaluate callbacks but maybe we can configure that somewhere
- the data structure I stored course data in is a hash of arrays, so we can choose to display the data however we like
```
{
  'CIS*3260': [
    [
      'Fall 2020',
      'Open',
      'CIS*1250*0101 (0928) Software Design I',
      'Guelph',
      'LEC Mon, Wed, Fri\n10:30AM - 11:20AM\nAD-S, Room Virtual\nLAB Mon\n11:30AM - 01:20PM\n',
      'L. Antonie',
      '1 / 1',
      '0.50',
      'Undergraduate'
    ],
    ...
  ],
  'CIS*1250': [],
  'CIS*1234': []
}
```
The array stored per open section corresponds to a column on WA, so we can easily access stuff
![image](https://user-images.githubusercontent.com/29992628/87834832-65930580-c859-11ea-9de4-b2b969ac0101.png)

Output with just one course:
![image](https://user-images.githubusercontent.com/29992628/87834920-aab73780-c859-11ea-9f4f-abff7ea60d06.png)

Output with multiple courses:
![image](https://user-images.githubusercontent.com/29992628/87834934-b9055380-c859-11ea-8b13-dface69548b9.png)

TTS is still present if a course has available sections.

LMK what you think